### PR TITLE
Fix MemTable flush and cache size tracking

### DIFF
--- a/akkara/engine/src/main/kotlin/dev/swiftstorm/akkaradb/engine/cache/HotReadCache.kt
+++ b/akkara/engine/src/main/kotlin/dev/swiftstorm/akkaradb/engine/cache/HotReadCache.kt
@@ -13,7 +13,11 @@ class HotReadCache(private val maxBytes: Long) {
 
     private val map = object : LinkedHashMap<ByteBuffer, Entry>(16, 0.75f, true) {
         override fun removeEldestEntry(eldest: MutableMap.MutableEntry<ByteBuffer, Entry>): Boolean {
-            return currentBytes > maxBytes
+            if (currentBytes > maxBytes) {
+                currentBytes -= eldest.value.size
+                return true
+            }
+            return false
         }
     }
 


### PR DESCRIPTION
## Summary
- reset flush state and size counters during MemTable flush
- correct MemTable eviction bookkeeping for currentBytes
- fix HotReadCache LRU eviction to adjust cached byte count

## Testing
- `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 PATH=$JAVA_HOME/bin:$PATH ./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_689ffdc1026c83258362a48197c337f7