### PR TITLE
Fix stripe buffer handling in reader/writer

### DIFF
--- a/akkara/format-api/src/main/kotlin/dev/swiftstorm/akkaradb/format/api/StripeReader.kt
+++ b/akkara/format-api/src/main/kotlin/dev/swiftstorm/akkaradb/format/api/StripeReader.kt
@@ -4,5 +4,10 @@ import java.io.Closeable
 import java.nio.ByteBuffer
 
 interface StripeReader : Closeable {
-    fun readStripe(): List<ByteBuffer>?
+    data class Stripe(
+        val payloads: List<ByteBuffer>,
+        val laneBlocks: List<ByteBuffer>
+    )
+
+    fun readStripe(): Stripe?
 }


### PR DESCRIPTION
## Summary
- retain data lane buffers until stripe commit in `AkkStripeWriter`
- expose lane blocks from `AkkStripeReader` and release them after scanning
- copy records during stripe scan to avoid pooling corruption

## Testing
- `./gradlew test` *(fails: trustAnchors parameter must be non-empty)*

------
https://chatgpt.com/codex/tasks/task_e_68a00bfa44a48325842473b08adf8849